### PR TITLE
Use pre-built image directly

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,5 +58,6 @@ inputs:
     description: Enables trace for entrypoint.sh
     required: false
 runs:
-  using: "docker"
-  image: "Dockerfile"
+  using: 'docker'
+  entrypoint: "/entrypoint.sh"
+  image: "docker://ghcr.io/aevea/action-kaniko/kaniko:v0.10.0"


### PR DESCRIPTION
ARC's k8s hook does not support building images for steps in a GHA workflow currently (0). Therefore we need to use the upstream pre-built image.

This will enable us to build container images without docker-in-docker. (0): https://github.com/vector-im/runner-container-hooks/blob/main/packages/k8s/src/hooks/run-container-step.ts#L26